### PR TITLE
Remove workflow conflicting button

### DIFF
--- a/ModProj/Assets/Toolkit/Scripts/GazeObj.cs
+++ b/ModProj/Assets/Toolkit/Scripts/GazeObj.cs
@@ -29,19 +29,6 @@ namespace CrossLink
         public string showName;
         public string showInfo;
         public GazeMgr.GazeType gazeType = GazeMgr.GazeType.NormalGaze;
-
-#if UNITY_EDITOR
-        [Button]
-        void PullGazeNameFromGameObject()
-        {
-            showName = gameObject.name;
-            showInfo = showName + "_Desc";
-            var ib = GetComponent<InteractBase>();
-            ib.gaze = this;
-            //enabled = false;
-            EditorUtility.SetDirty(gameObject);
-        }
-#endif
     }
 
 }


### PR DESCRIPTION
This button was used for retrieving the name of the prefab and placcing it in the gaze component.
Since the workflow has now changed and weapon prefabs no longer contain the prefix this button conflicts with the current workflow and should be removed.  